### PR TITLE
Refactored the migrate method to support a one migration per batch mode

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -57,26 +57,52 @@ func Register(name string, up, down func(*pg.Tx) error) {
 	}
 }
 
-func Run(db *pg.DB, cmd, name, template string) error {
+/*
+Run Runs the specified command with the options they require
+Note:
+	init - no options
+	migrate - one option
+		- "" for all migrations in a single batch
+		- "one-by-one" for one migration in a batch mode
+	rollback - no options
+	create - two options
+		- name - name of the migration (must be first)
+		- template - string that contains the go code to use as a template. see migrationTemplate
+*/
+func Run(db *pg.DB, cmd string, options ...string) error {
 	switch cmd {
 	case "init":
 		return initialise(db)
+
 	case "migrate":
-		return migrate(db)
+		extra := ""
+		if len(options) > 0 {
+			extra = options[0]
+		}
+		return migrate(db, extra == "one-by-one")
+
 	case "rollback":
 		return rollback(db)
+
 	case "create":
+		name := ""
+		template := ""
+		if len(options) > 0 {
+			name = options[0]
+		}
+		if len(options) > 1 {
+			template = options[1]
+		}
 		if len(name) == 0 {
-			return errors.New("Please enter migration description")
+			return errors.New("Please enter migration name")
 		}
 
 		name = strings.Replace(name, " ", "_", -1)
 
 		return create(name, template)
-	default:
-		return errors.Errorf("unsupported command: %q", cmd)
-
 	}
+
+	return errors.Errorf("unsupported command: %q", cmd)
 }
 
 func initialise(db *pg.DB) error {
@@ -127,68 +153,135 @@ func initialise(db *pg.DB) error {
 	})
 }
 
-func migrate(db *pg.DB) error {
-	return db.RunInTransaction(func(tx *pg.Tx) (err error) {
+func getMigrationsToRun(tx *pg.Tx) ([]string, error) {
+	var migrations []string
 
-		err = lockTable(tx)
+	migrations, err := getCompletedMigrations(tx)
+	if err != nil {
+		return nil, err
+	}
 
-		if err != nil {
-			return
-		}
+	missingMigrations := difference(migrations, migrationNames)
+	if len(missingMigrations) > 0 {
+		return nil, errors.Errorf("Migrations table corrupt: %+v", missingMigrations)
+	}
 
-		var migrations []string
+	migrationsToRun := difference(migrationNames, migrations)
 
-		migrations, err = getCompletedMigrations(tx)
+	if len(migrationsToRun) > 0 {
+		sort.Strings(migrationsToRun)
+	}
 
-		if err != nil {
-			return
-		}
+	return migrationsToRun, nil
+}
+func migrate(db *pg.DB, oneByOne bool) error {
+	if oneByOne {
+		return migrateOneByOne(db)
+	}
+	return migrateOneBatch(db)
+}
 
-		missingMigrations := difference(migrations, migrationNames)
+func migrateOneByOne(db *pg.DB) error {
 
-		if len(missingMigrations) > 0 {
-			return errors.Errorf("Migrations table corrupt: %+v", missingMigrations)
-		}
+	var migrationsToRun []string
 
-		migrationsToRun := difference(migrationNames, migrations)
-
-		if len(migrationsToRun) > 0 {
-			var batch int
-			batch, err = getBatchNumber(tx)
-
+	err := db.RunInTransaction(
+		func(tx *pg.Tx) (err error) {
+			err = lockTable(tx)
 			if err != nil {
 				return
 			}
 
-			batch++
+			migrationsToRun, err = getMigrationsToRun(tx)
+			return
+		})
 
-			sort.Slice(migrationsToRun, func(i, j int) bool {
-				switch strings.Compare(migrationsToRun[i], migrationsToRun[j]) {
-				case -1:
-					return true
-				case 1:
-					return false
+	if err != nil {
+		return err
+	}
+
+	if len(migrationsToRun) == 0 {
+		return nil
+	}
+
+	for _, migration := range migrationsToRun {
+		err := db.RunInTransaction(
+			func(tx *pg.Tx) (err error) {
+				err = lockTable(tx)
+				if err != nil {
+					return
 				}
-				return true
-			})
 
-			fmt.Printf("Batch %d run: %d migrations\n", batch, len(migrationsToRun))
+				var batch int
+				batch, err = getBatchNumber(tx)
+				if err != nil {
+					return
+				}
 
-			for _, migration := range migrationsToRun {
+				batch++
+
+				fmt.Printf("Batch %d run: 1 migration - %s\n", batch, migration)
+
 				err = allMigrations[migration].Up(tx)
-
 				if err != nil {
 					err = errors.Wrapf(err, "%s failed to migrate", migration)
 					return
 				}
 
 				err = insertCompletedMigration(tx, migration, batch)
+				return
+			})
+		if err != nil {
+			return err
+		}
+	}
 
-				if err != nil {
-					return
-				}
+	return nil
+}
+
+func migrateOneBatch(db *pg.DB) error {
+	return db.RunInTransaction(func(tx *pg.Tx) (err error) {
+
+		err = lockTable(tx)
+		if err != nil {
+			return
+		}
+
+		var migrationsToRun []string
+		migrationsToRun, err = getMigrationsToRun(tx)
+		if err != nil {
+			return
+		}
+
+		if len(migrationsToRun) == 0 {
+			return
+		}
+
+		var batch int
+		batch, err = getBatchNumber(tx)
+		if err != nil {
+			return
+		}
+
+		batch++
+
+		fmt.Printf("Batch %d run: %d migrations\n", batch, len(migrationsToRun))
+
+		for _, migration := range migrationsToRun {
+			err = allMigrations[migration].Up(tx)
+
+			if err != nil {
+				err = errors.Wrapf(err, "%s failed to migrate", migration)
+				return
+			}
+
+			err = insertCompletedMigration(tx, migration, batch)
+
+			if err != nil {
+				return
 			}
 		}
+
 		return
 	})
 }


### PR DESCRIPTION
The reason for this is that some users of the engine have large batches and these cause deadlocks. So running one migration at a time puts the power back into the developer of the migration's hands to ensure no deadlocks occur.

Refactored the parameters taken by Run to be cmd + options... to allow for future enhancements without breaking interface changes. Included a bunch of needed documentation.